### PR TITLE
Added tooltip for confirmation-email code

### DIFF
--- a/Client/apps/SdHub/src/app/pages/auth/login-form/login-form.component.html
+++ b/Client/apps/SdHub/src/app/pages/auth/login-form/login-form.component.html
@@ -43,6 +43,12 @@
 
   <mat-form-field appearance="fill">
     <mat-label>Code from email</mat-label>
+    <mat-icon
+      matSuffix
+      matTooltip="Check your spam folder in case you don't see an email"
+      matTooltipPosition="above">
+      help_outline
+    </mat-icon>
     <input type="text"
            formControlName="code"
            matInput


### PR DESCRIPTION
Первый вариант, который в голову пришёл.
![image](https://user-images.githubusercontent.com/116700539/205434164-fde579a3-4687-423b-83ae-68400dead976.png)
