### PR TITLE
Image-cards actions and bunch operations

### DIFF
--- a/Client/apps/SdHub/src/app/core/services/image-selection.service.ts
+++ b/Client/apps/SdHub/src/app/core/services/image-selection.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, map } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ImageSelectionService {
+
+  private _selectedImages$ = new BehaviorSubject<string[]>([]);
+
+  public selectedImages$ = this._selectedImages$.asObservable();
+
+  public hasSelectedImages$ = this._selectedImages$.pipe(
+    map((selectedImages) => selectedImages.length > 0)
+  );
+
+  public toggleSelected(imageToken: string) {
+    const previousValue = this._selectedImages$.value;
+    const needDelete = previousValue.includes(imageToken);
+
+    const updatedState = needDelete
+      ? previousValue.filter((val) => val !== imageToken)
+      : [...previousValue, imageToken];
+
+    this._selectedImages$.next(updatedState);
+  }
+
+  public isSelected(imageToken: string) {
+    return this._selectedImages$.pipe(
+      map((selectedImages) => selectedImages.includes(imageToken))
+    )
+  }
+
+  public getSelectedImages() {
+    return this._selectedImages$.getValue();
+  }
+
+  public clearSelection() {
+    this._selectedImages$.next([]);
+  }
+}

--- a/Client/apps/SdHub/src/app/core/services/my-albums.service.ts
+++ b/Client/apps/SdHub/src/app/core/services/my-albums.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { AlbumApi } from '../../shared/services/api/album.api';
 import { AuthStateService } from './auth-state.service';
@@ -9,16 +9,11 @@ export class MyAlbumsService {
 
   private reloadAlbums$ = new BehaviorSubject(null);
 
-  private currentUsername$ = this.authStateService.user$.pipe(
-    map((user) => user?.login),
-    shareReplay(1)
-  );
-
   private myAlbumsRes$ = this.reloadAlbums$.pipe(
-    switchMap(() => this.currentUsername$),
-    switchMap((username) => username
-      ? this.albumsApi.search({ owner: username })
-      : []
+    switchMap(() => this.authStateService.user$),
+    switchMap((user) => user?.login
+      ? this.albumsApi.search({ owner: user.login })
+      : of({ albums: [], total: 0 })
     ),
     shareReplay(1)
   );

--- a/Client/apps/SdHub/src/app/core/services/my-albums.service.ts
+++ b/Client/apps/SdHub/src/app/core/services/my-albums.service.ts
@@ -1,0 +1,48 @@
+
+
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
+import { AlbumApi } from '../../shared/services/api/album.api';
+import { AuthStateService } from './auth-state.service';
+
+@Injectable({ providedIn: 'root' })
+export class MyAlbumsService {
+
+  private reloadAlbums$ = new BehaviorSubject(null);
+
+  private currentUsername$ = this.authStateService.user$.pipe(
+    map((user) => user?.login),
+    shareReplay(1)
+  );
+
+  private myAlbumsRes$ = this.reloadAlbums$.pipe(
+    switchMap(() => this.currentUsername$),
+    switchMap((username) => username
+      ? this.albumsApi.search({ owner: username })
+      : []
+    ),
+    shareReplay(1)
+  );
+
+  public myAlbums$ = this.myAlbumsRes$.pipe(
+    map(({ albums }) => albums),
+    shareReplay(1)
+  )
+
+  public myAlbumsTotal$ = this.myAlbumsRes$.pipe(
+    map(({ total }) => total),
+    shareReplay(1)
+  );
+
+  public hasAlbums$ = this.myAlbumsTotal$.pipe(
+    map((total) => total > 0),
+    shareReplay(1)
+  );
+
+  constructor(private authStateService: AuthStateService, private albumsApi: AlbumApi) { }
+
+  public reloadAlbums() {
+    this.reloadAlbums$.next(null);
+  }
+}

--- a/Client/apps/SdHub/src/app/core/services/my-albums.service.ts
+++ b/Client/apps/SdHub/src/app/core/services/my-albums.service.ts
@@ -1,5 +1,3 @@
-
-
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';

--- a/Client/apps/SdHub/src/app/models/autogen/image.models.ts
+++ b/Client/apps/SdHub/src/app/models/autogen/image.models.ts
@@ -2,7 +2,8 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 
-import { IEditImageModel, IImageModel } from './misc.models';
+import { IEditImageModel } from './misc.models';
+import { IImageModel } from './misc.models';
 
 export interface IDeleteImageRequest
 {

--- a/Client/apps/SdHub/src/app/models/autogen/image.models.ts
+++ b/Client/apps/SdHub/src/app/models/autogen/image.models.ts
@@ -2,13 +2,12 @@
 //     Changes to this file may cause incorrect behavior and will be lost if
 //     the code is regenerated.
 
-import { IEditImageModel } from './misc.models';
-import { IImageModel } from './misc.models';
+import { IEditImageModel, IImageModel } from './misc.models';
 
 export interface IDeleteImageRequest
 {
 	shortToken: string;
-	manageToken: string;
+	manageToken: string | null;
 }
 export interface IDeleteImageResponse
 {

--- a/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.html
+++ b/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.html
@@ -72,6 +72,11 @@
       </mat-card>
     </ng-template>
 
+    <image-bunch-actions-panel
+      [displayedImages]="searchResult?.images ?? []"
+      [selectedAlbum]="album"
+      (needReloadImages)="onReloadImages()">
+    </image-bunch-actions-panel>
 
     <div #scrollTo
          style="display: flex; flex-direction: column; flex-grow: 1">
@@ -90,7 +95,10 @@
       <div *ngIf="(searchResult?.total ?? 0) > 0 && !loading"
            class="search-result-container">
         <div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: .5rem">
-          <small-image-card *ngFor="let img of searchResult?.images ?? []" [imageInfo]="img">
+          <small-image-card
+            *ngFor="let img of searchResult?.images ?? []"
+            [imageInfo]="img"
+            [selectedAlbum]="album">
           </small-image-card>
         </div>
         <div style="flex-grow: 1"></div>

--- a/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.html
+++ b/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.html
@@ -98,7 +98,8 @@
           <small-image-card
             *ngFor="let img of searchResult?.images ?? []"
             [imageInfo]="img"
-            [selectedAlbum]="album">
+            [selectedAlbum]="album"
+            (needReloadImages)="onReloadImages()">
           </small-image-card>
         </div>
         <div style="flex-grow: 1"></div>

--- a/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.ts
+++ b/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.ts
@@ -17,6 +17,8 @@ import { httpErrorResponseHandler } from 'apps/SdHub/src/app/shared/http-error-h
 import { AlbumApi } from 'apps/SdHub/src/app/shared/services/api/album.api';
 import { ImageApi } from 'apps/SdHub/src/app/shared/services/api/image.api';
 import { ToastrService } from 'ngx-toastr';
+import { ImageSelectionService } from '../../../core/services/image-selection.service';
+import { MyAlbumsService } from '../../../core/services/my-albums.service';
 
 interface IAlbumEdit {
   name: string | null;
@@ -54,6 +56,8 @@ export class AlbumPageComponent implements OnInit {
   constructor(private imageApi: ImageApi,
               private albumApi: AlbumApi,
               private toastr: ToastrService,
+              private myAlbumsService: MyAlbumsService,
+              private imageSelectionService: ImageSelectionService,
               private route: ActivatedRoute,
               private router: Router,
               private clipboard: Clipboard,
@@ -130,6 +134,7 @@ export class AlbumPageComponent implements OnInit {
       next: resp => {
         this.editMode = false;
         this.applyLoadedAlbum(resp);
+        this.myAlbumsService.reloadAlbums();
         this.toastr.success('All changes saved');
       },
       error: (err: HttpErrorResponse) => {
@@ -145,6 +150,7 @@ export class AlbumPageComponent implements OnInit {
     }).subscribe({
       next: resp => {
         this.editMode = false;
+        this.myAlbumsService.reloadAlbums();
         this.toastr.success('Deleted (┬┬﹏┬┬)');
         void this.router.navigate(['/']);
       },
@@ -174,6 +180,7 @@ export class AlbumPageComponent implements OnInit {
       album: this.shortToken,
     }).subscribe({
       next: resp => {
+        this.imageSelectionService.clearSelection();
         this.loadingImages = false;
         this.searchResult = resp;
         this.totalPages = Math.floor(resp.total / this.pageSize) + ((resp.total % this.pageSize) === 0 ? 0 : 1);

--- a/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.ts
+++ b/Client/apps/SdHub/src/app/pages/album/album-page/album-page.component.ts
@@ -1,22 +1,22 @@
-import {Component, ElementRef, OnInit, ViewChild} from '@angular/core';
-import {PerformType} from "apps/SdHub/src/app/pages/generated/search-page/search-page.component";
+import { Clipboard } from '@angular/cdk/clipboard';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { ActivatedRoute, Router } from '@angular/router';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { AuthStateService } from 'apps/SdHub/src/app/core/services/auth-state.service';
+import { IAlbumModel } from 'apps/SdHub/src/app/models/autogen/album.models';
 import {
   ISearchImageResponse,
   SearchImageOrderByFieldType,
   SearchImageOrderByType
-} from "apps/SdHub/src/app/models/autogen/image.models";
-import {HttpErrorResponse} from "@angular/common/http";
-import {httpErrorResponseHandler} from "apps/SdHub/src/app/shared/http-error-handling/handlers";
-import {ImageApi} from "apps/SdHub/src/app/shared/services/api/image.api";
-import {AlbumApi} from "apps/SdHub/src/app/shared/services/api/album.api";
-import {ToastrService} from "ngx-toastr";
-import {ActivatedRoute, Router} from "@angular/router";
-import {Clipboard} from "@angular/cdk/clipboard";
-import {AuthStateService} from "apps/SdHub/src/app/core/services/auth-state.service";
-import {MatDialog} from "@angular/material/dialog";
-import {UntilDestroy, untilDestroyed} from "@ngneat/until-destroy";
-import {IImageOwnerModel} from "apps/SdHub/src/app/models/autogen/misc.models";
-import {IAlbumModel} from "apps/SdHub/src/app/models/autogen/album.models";
+} from 'apps/SdHub/src/app/models/autogen/image.models';
+import { IImageOwnerModel } from 'apps/SdHub/src/app/models/autogen/misc.models';
+import { PerformType } from 'apps/SdHub/src/app/pages/generated/search-page/search-page.component';
+import { httpErrorResponseHandler } from 'apps/SdHub/src/app/shared/http-error-handling/handlers';
+import { AlbumApi } from 'apps/SdHub/src/app/shared/services/api/album.api';
+import { ImageApi } from 'apps/SdHub/src/app/shared/services/api/image.api';
+import { ToastrService } from 'ngx-toastr';
 
 interface IAlbumEdit {
   name: string | null;
@@ -41,6 +41,7 @@ export class AlbumPageComponent implements OnInit {
   public description = '';
   public shortToken = '';
   public albumOwner: IImageOwnerModel | null = null;
+  public album: IAlbumModel | null = null;
 
   @ViewChild('scrollTo', {read: ElementRef}) scrollTo?: ElementRef;
 
@@ -96,6 +97,7 @@ export class AlbumPageComponent implements OnInit {
     this.name = album.name;
     this.thumbUrl = album.thumbImage?.directUrl ?? '';
     this.shortToken = album.shortToken;
+    this.album = album;
 
     this.canEdit = this.currentUser === this.albumOwner?.login;
   }
@@ -113,6 +115,10 @@ export class AlbumPageComponent implements OnInit {
 
   public onCancelClick(): void {
     this.editMode = false;
+  }
+
+  public onReloadImages(): void {
+    this.runImageSearch(PerformType.Search);
   }
 
   public onSaveClick(): void {
@@ -175,7 +181,7 @@ export class AlbumPageComponent implements OnInit {
           this.page = 0;
         }
         if (type === PerformType.Pagination) {
-          this.scrollTo?.nativeElement?.scrollIntoView({behavior: "smooth"});
+          this.scrollTo?.nativeElement?.scrollIntoView({behavior: 'smooth'});
         }
       },
       error: (err: HttpErrorResponse) => {

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
@@ -51,7 +51,10 @@
        #scrollTo
        class="search-result-container">
     <div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: .5rem">
-      <small-image-card *ngFor="let img of searchResult?.images ?? []" [imageInfo]="img">
+      <small-image-card
+        *ngFor="let img of searchResult?.images ?? []"
+        [imageInfo]="img"
+        (imageDeleted)="onImageDeleted()">
       </small-image-card>
     </div>
     <div style="flex-grow: 1"></div>

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
@@ -36,32 +36,10 @@
     </mat-card>
   </div>
 
-  <div class="actions"
-    [class.actions_visible]="hasSelectedImages$ | async"
-    [class.actions_unavailable]="areActionsUnavailable$ | async">
-    <button mat-raised-button (click)="cancelSelection()">
-      <mat-icon>library_add_check</mat-icon>
-      <span>Cancel selection</span>
-    </button>
-    <button *ngIf="hasAlbums$ | async" mat-raised-button color="primary" [matMenuTriggerFor]="albumsMenu">
-      <mat-icon>photo_library</mat-icon>
-      <span>Add to album</span>
-    </button>
-    <button *ngIf="canDelete$ | async" mat-raised-button color="warn" (click)="deleteSelectedImages()">
-      <mat-icon>delete</mat-icon>
-      <span>Delete</span>
-    </button>
-
-    <mat-menu #albumsMenu="matMenu">
-      <button
-        *ngFor="let album of myAlbums$ | async"
-        mat-menu-item
-        (click)="addSelectedImagesToAlbum(album.shortToken)">
-        <mat-icon>photo_library</mat-icon>
-        <span>{{ album.name }}</span>
-      </button>
-    </mat-menu>
-  </div>
+  <image-bunch-actions-panel
+    [displayedImages]="(searchResult$ | async)?.images ?? []"
+    (needReloadImages)="onReloadImages()">
+  </image-bunch-actions-panel>
 
   <div *ngIf="((searchResult$ | async)?.total ?? 0) === 0 && !loading"
        class="search-result-placeholder-container">
@@ -81,7 +59,7 @@
       <small-image-card
         *ngFor="let img of (searchResult$ | async)?.images ?? []"
         [imageInfo]="img"
-        (imageDeleted)="onImageDeleted()">
+        (needReloadImages)="onReloadImages()">
       </small-image-card>
     </div>
     <div style="flex-grow: 1"></div>

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
@@ -37,11 +37,11 @@
   </div>
 
   <image-bunch-actions-panel
-    [displayedImages]="(searchResult$ | async)?.images ?? []"
+    [displayedImages]="searchResult?.images ?? []"
     (needReloadImages)="onReloadImages()">
   </image-bunch-actions-panel>
 
-  <div *ngIf="((searchResult$ | async)?.total ?? 0) === 0 && !loading"
+  <div *ngIf="(searchResult?.total ?? 0) === 0 && !loading"
        class="search-result-placeholder-container">
     <div>Nothing found ＞︿＜</div>
   </div>
@@ -52,12 +52,12 @@
       <mat-progress-bar mode="query"></mat-progress-bar>
     </div>
   </div>
-  <div *ngIf="((searchResult$ | async)?.total ?? 0) > 0 && !loading"
+  <div *ngIf="(searchResult?.total ?? 0) > 0 && !loading"
        #scrollTo
        class="search-result-container">
     <div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: .5rem">
       <small-image-card
-        *ngFor="let img of (searchResult$ | async)?.images ?? []"
+        *ngFor="let img of searchResult?.images ?? []"
         [imageInfo]="img"
         (needReloadImages)="onReloadImages()">
       </small-image-card>

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.html
@@ -36,7 +36,34 @@
     </mat-card>
   </div>
 
-  <div *ngIf="(searchResult?.total ?? 0) === 0 && !loading"
+  <div class="actions"
+    [class.actions_visible]="hasSelectedImages$ | async"
+    [class.actions_unavailable]="areActionsUnavailable$ | async">
+    <button mat-raised-button (click)="cancelSelection()">
+      <mat-icon>library_add_check</mat-icon>
+      <span>Cancel selection</span>
+    </button>
+    <button *ngIf="hasAlbums$ | async" mat-raised-button color="primary" [matMenuTriggerFor]="albumsMenu">
+      <mat-icon>photo_library</mat-icon>
+      <span>Add to album</span>
+    </button>
+    <button *ngIf="canDelete$ | async" mat-raised-button color="warn" (click)="deleteSelectedImages()">
+      <mat-icon>delete</mat-icon>
+      <span>Delete</span>
+    </button>
+
+    <mat-menu #albumsMenu="matMenu">
+      <button
+        *ngFor="let album of myAlbums$ | async"
+        mat-menu-item
+        (click)="addSelectedImagesToAlbum(album.shortToken)">
+        <mat-icon>photo_library</mat-icon>
+        <span>{{ album.name }}</span>
+      </button>
+    </mat-menu>
+  </div>
+
+  <div *ngIf="((searchResult$ | async)?.total ?? 0) === 0 && !loading"
        class="search-result-placeholder-container">
     <div>Nothing found ＞︿＜</div>
   </div>
@@ -47,12 +74,12 @@
       <mat-progress-bar mode="query"></mat-progress-bar>
     </div>
   </div>
-  <div *ngIf="(searchResult?.total ?? 0) > 0 && !loading"
+  <div *ngIf="((searchResult$ | async)?.total ?? 0) > 0 && !loading"
        #scrollTo
        class="search-result-container">
     <div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: .5rem">
       <small-image-card
-        *ngFor="let img of searchResult?.images ?? []"
+        *ngFor="let img of (searchResult$ | async)?.images ?? []"
         [imageInfo]="img"
         (imageDeleted)="onImageDeleted()">
       </small-image-card>

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.scss
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.scss
@@ -11,6 +11,23 @@
   gap: .6rem;
 }
 
+.actions {
+  position: sticky;
+  top: 15px;
+  display: flex;
+  gap: 10px;
+  z-index: 2;
+  visibility: hidden;
+
+  &_visible {
+    visibility: visible;
+  }
+
+  &_unavailable {
+    display: none;
+  }
+}
+
 .search-result-placeholder-container {
   display: flex;
   flex-direction: column;

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.scss
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.scss
@@ -11,23 +11,6 @@
   gap: .6rem;
 }
 
-.actions {
-  position: sticky;
-  top: 15px;
-  display: flex;
-  gap: 10px;
-  z-index: 2;
-  visibility: hidden;
-
-  &_visible {
-    visibility: visible;
-  }
-
-  &_unavailable {
-    display: none;
-  }
-}
-
 .search-result-placeholder-container {
   display: flex;
   flex-direction: column;

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
@@ -124,6 +124,10 @@ export class SearchInImagesComponent implements OnInit {
         });
     }
 
+    public onImageDeleted(): void {
+        this.runSearch(PerformType.Search);
+    }
+
     public onPageChange(): void {
         this.runSearch(PerformType.Pagination);
     }

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
@@ -1,18 +1,27 @@
-import {Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild} from '@angular/core';
+import { HttpErrorResponse } from "@angular/common/http";
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import {
-    ISearchImageResponse,
-    SearchImageInFieldType,
-    SearchImageOrderByFieldType,
-    SearchImageOrderByType,
-    SoftwareGeneratedTypes
+  ISearchImageResponse,
+  SearchImageInFieldType,
+  SearchImageOrderByFieldType,
+  SearchImageOrderByType,
+  SoftwareGeneratedTypes
 } from "apps/SdHub/src/app/models/autogen/image.models";
-import {Observable} from "rxjs";
-import {UntilDestroy, untilDestroyed} from "@ngneat/until-destroy";
-import {ImageApi} from "apps/SdHub/src/app/shared/services/api/image.api";
-import {HttpErrorResponse} from "@angular/common/http";
-import {httpErrorResponseHandler} from "apps/SdHub/src/app/shared/http-error-handling/handlers";
-import {ToastrService} from "ngx-toastr";
-import {PerformType} from "apps/SdHub/src/app/pages/generated/search-page/search-page.component";
+import { PerformType } from "apps/SdHub/src/app/pages/generated/search-page/search-page.component";
+import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
+import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
+import { Dictionary, keyBy } from 'lodash';
+import { ToastrService } from "ngx-toastr";
+import { BehaviorSubject, combineLatest, filter, forkJoin, map, Observable } from "rxjs";
+import { switchMap } from "rxjs/operators";
+import { AuthStateService } from '../../../core/services/auth-state.service';
+import { ImageSelectionService } from '../../../core/services/image-selection.service';
+import { MyAlbumsService } from '../../../core/services/my-albums.service';
+import { IImageModel } from '../../../models/autogen/misc.models';
+import { ConfirmDialogComponent, ConfirmDialogModel } from '../../../shared/components/confirm-dialog/confirm-dialog.component';
+import { AlbumApi } from '../../../shared/services/api/album.api';
 
 @UntilDestroy()
 @Component({
@@ -20,7 +29,7 @@ import {PerformType} from "apps/SdHub/src/app/pages/generated/search-page/search
     templateUrl: './search-in-images.component.html',
     styleUrls: ['./search-in-images.component.scss'],
 })
-export class SearchInImagesComponent implements OnInit {
+export class SearchInImagesComponent implements OnInit, OnDestroy {
     public readonly orderBy: { name: string, field: SearchImageOrderByFieldType, order: SearchImageOrderByType | null, icon: string | null }[] = [
         {
             name: 'Upload date',
@@ -73,16 +82,64 @@ export class SearchInImagesComponent implements OnInit {
     public onlyFromRegisteredUsers = true;
     public searchAsRegexp = false;
     public loading = false;
-    public searchResult: ISearchImageResponse | null = null;
+    public searchResult$ = new BehaviorSubject<ISearchImageResponse | null>(null);
     public pageSize = 50;
     public page = 0;
     public totalPages = 1;
 
-    constructor(private imageApi: ImageApi,
-                private toastr: ToastrService,) {
-    }
+    public myAlbums$ = this.myAlbumsService.myAlbums$;
+
+    public hasAlbums$ = this.myAlbumsService.hasAlbums$;
+
+    private displayedImagesByShortToken$ = this.searchResult$.pipe(
+      map((searchResult) => {
+        if(!searchResult?.images) {
+          return {} as Dictionary<IImageModel>;
+        }
+
+        return keyBy(searchResult.images, (img) => img.shortToken);
+      })
+    )
+
+    public areActionsUnavailable$ = this.authStateService.user$.pipe(
+      map((user) => !user)
+    );
+
+    public canDelete$ = combineLatest([
+      this.authStateService.user$,
+      this.displayedImagesByShortToken$,
+      this.imagesSelectionService.selectedImages$
+    ]).pipe(
+      map(([user, displayedImagesByShortToken, selectedImages]) => {
+        if (!user) {
+          return false;
+        }
+
+        return selectedImages
+          .every((shortImageToken) => {
+            const selectedImageInfo = displayedImagesByShortToken[shortImageToken];
+            return selectedImageInfo?.owner?.login === user.login
+          })
+      })
+    );
+
+    public hasSelectedImages$ = this.imagesSelectionService.hasSelectedImages$;
+
+    constructor(
+      private imageApi: ImageApi,
+      private toastr: ToastrService,
+      private albumApi: AlbumApi,
+      private dialog: MatDialog,
+      private myAlbumsService: MyAlbumsService,
+      private authStateService: AuthStateService,
+      private imagesSelectionService: ImageSelectionService,
+    ) { }
 
     ngOnInit(): void {
+    }
+
+    ngOnDestroy(): void {
+      this.imagesSelectionService.clearSelection();
     }
 
     private runSearch(type: PerformType): void {
@@ -107,7 +164,7 @@ export class SearchInImagesComponent implements OnInit {
         }).subscribe({
             next: resp => {
                 this.loading = false;
-                this.searchResult = resp;
+                this.searchResult$.next(resp);
                 this.totalPages = Math.floor(resp.total / this.pageSize) + ((resp.total % this.pageSize) === 0 ? 0 : 1);
                 if (type === PerformType.Search) {
                     this.page = 0;
@@ -118,7 +175,7 @@ export class SearchInImagesComponent implements OnInit {
             },
             error: (err: HttpErrorResponse) => {
                 this.loading = false;
-                this.searchResult = null;
+                this.searchResult$.next(null);
                 httpErrorResponseHandler(err, this.toastr);
             }
         });
@@ -148,4 +205,50 @@ export class SearchInImagesComponent implements OnInit {
             }
         }
     }
+
+    public cancelSelection() {
+      this.imagesSelectionService.clearSelection();
+    }
+
+    public addSelectedImagesToAlbum(albumShortToken: string) {
+      this.albumApi
+        .addImages({
+          albumShortToken,
+          images: this.imagesSelectionService.getSelectedImages()
+        })
+        .subscribe(() => {
+          this.imagesSelectionService.clearSelection();
+          this.toastr.success('Images were added to the album');
+        });
+    }
+
+    public deleteSelectedImages() {
+      this.dialog
+        .open<ConfirmDialogComponent, ConfirmDialogModel, boolean>(
+          ConfirmDialogComponent, {
+            data: {
+              title: 'Delete image',
+              message: 'Are you sure you want to delete these images?'
+            }
+          }
+        )
+        .afterClosed()
+        .pipe(
+          filter((res) => !!res),
+          map(() => this.imagesSelectionService
+            .getSelectedImages()
+            .map((shortToken) => this.imageApi.delete({
+              shortToken: shortToken,
+              manageToken: null
+            }))
+          ),
+          switchMap((requests) => forkJoin(requests)),
+        )
+        .subscribe(() => {
+          this.imagesSelectionService.clearSelection();
+          this.toastr.success('Images were deleted');
+          this.runSearch(PerformType.Search);
+        });
+    }
 }
+

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
@@ -12,7 +12,7 @@ import { PerformType } from "apps/SdHub/src/app/pages/generated/search-page/sear
 import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
 import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, Observable } from "rxjs";
+import { Observable } from "rxjs";
 import { ImageSelectionService } from '../../../core/services/image-selection.service';
 
 @UntilDestroy()
@@ -74,7 +74,7 @@ export class SearchInImagesComponent implements OnInit {
     public onlyFromRegisteredUsers = true;
     public searchAsRegexp = false;
     public loading = false;
-    public searchResult$ = new BehaviorSubject<ISearchImageResponse | null>(null);
+    public searchResult: ISearchImageResponse | null = null;
     public pageSize = 50;
     public page = 0;
     public totalPages = 1;
@@ -111,7 +111,7 @@ export class SearchInImagesComponent implements OnInit {
             next: resp => {
                 this.imageSelectionService.clearSelection();
                 this.loading = false;
-                this.searchResult$.next(resp);
+                this.searchResult = resp;
                 this.totalPages = Math.floor(resp.total / this.pageSize) + ((resp.total % this.pageSize) === 0 ? 0 : 1);
                 if (type === PerformType.Search) {
                     this.page = 0;
@@ -122,7 +122,7 @@ export class SearchInImagesComponent implements OnInit {
             },
             error: (err: HttpErrorResponse) => {
                 this.loading = false;
-                this.searchResult$.next(null);
+                this.searchResult = null;
                 httpErrorResponseHandler(err, this.toastr);
             }
         });

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
@@ -1,6 +1,5 @@
 import { HttpErrorResponse } from "@angular/common/http";
-import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import {
   ISearchImageResponse,
@@ -12,16 +11,8 @@ import {
 import { PerformType } from "apps/SdHub/src/app/pages/generated/search-page/search-page.component";
 import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
 import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
-import { Dictionary, keyBy } from 'lodash';
 import { ToastrService } from "ngx-toastr";
-import { BehaviorSubject, combineLatest, filter, forkJoin, map, Observable } from "rxjs";
-import { switchMap } from "rxjs/operators";
-import { AuthStateService } from '../../../core/services/auth-state.service';
-import { ImageSelectionService } from '../../../core/services/image-selection.service';
-import { MyAlbumsService } from '../../../core/services/my-albums.service';
-import { IImageModel } from '../../../models/autogen/misc.models';
-import { ConfirmDialogComponent, ConfirmDialogModel } from '../../../shared/components/confirm-dialog/confirm-dialog.component';
-import { AlbumApi } from '../../../shared/services/api/album.api';
+import { BehaviorSubject, Observable } from "rxjs";
 
 @UntilDestroy()
 @Component({
@@ -29,7 +20,7 @@ import { AlbumApi } from '../../../shared/services/api/album.api';
     templateUrl: './search-in-images.component.html',
     styleUrls: ['./search-in-images.component.scss'],
 })
-export class SearchInImagesComponent implements OnInit, OnDestroy {
+export class SearchInImagesComponent implements OnInit {
     public readonly orderBy: { name: string, field: SearchImageOrderByFieldType, order: SearchImageOrderByType | null, icon: string | null }[] = [
         {
             name: 'Upload date',
@@ -87,59 +78,12 @@ export class SearchInImagesComponent implements OnInit, OnDestroy {
     public page = 0;
     public totalPages = 1;
 
-    public myAlbums$ = this.myAlbumsService.myAlbums$;
-
-    public hasAlbums$ = this.myAlbumsService.hasAlbums$;
-
-    private displayedImagesByShortToken$ = this.searchResult$.pipe(
-      map((searchResult) => {
-        if(!searchResult?.images) {
-          return {} as Dictionary<IImageModel>;
-        }
-
-        return keyBy(searchResult.images, (img) => img.shortToken);
-      })
-    )
-
-    public areActionsUnavailable$ = this.authStateService.user$.pipe(
-      map((user) => !user)
-    );
-
-    public canDelete$ = combineLatest([
-      this.authStateService.user$,
-      this.displayedImagesByShortToken$,
-      this.imagesSelectionService.selectedImages$
-    ]).pipe(
-      map(([user, displayedImagesByShortToken, selectedImages]) => {
-        if (!user) {
-          return false;
-        }
-
-        return selectedImages
-          .every((shortImageToken) => {
-            const selectedImageInfo = displayedImagesByShortToken[shortImageToken];
-            return selectedImageInfo?.owner?.login === user.login
-          })
-      })
-    );
-
-    public hasSelectedImages$ = this.imagesSelectionService.hasSelectedImages$;
-
     constructor(
       private imageApi: ImageApi,
       private toastr: ToastrService,
-      private albumApi: AlbumApi,
-      private dialog: MatDialog,
-      private myAlbumsService: MyAlbumsService,
-      private authStateService: AuthStateService,
-      private imagesSelectionService: ImageSelectionService,
     ) { }
 
     ngOnInit(): void {
-    }
-
-    ngOnDestroy(): void {
-      this.imagesSelectionService.clearSelection();
     }
 
     private runSearch(type: PerformType): void {
@@ -181,7 +125,7 @@ export class SearchInImagesComponent implements OnInit, OnDestroy {
         });
     }
 
-    public onImageDeleted(): void {
+    public onReloadImages(): void {
         this.runSearch(PerformType.Search);
     }
 
@@ -204,51 +148,6 @@ export class SearchInImagesComponent implements OnInit, OnDestroy {
                 entry.icon = null;
             }
         }
-    }
-
-    public cancelSelection() {
-      this.imagesSelectionService.clearSelection();
-    }
-
-    public addSelectedImagesToAlbum(albumShortToken: string) {
-      this.albumApi
-        .addImages({
-          albumShortToken,
-          images: this.imagesSelectionService.getSelectedImages()
-        })
-        .subscribe(() => {
-          this.imagesSelectionService.clearSelection();
-          this.toastr.success('Images were added to the album');
-        });
-    }
-
-    public deleteSelectedImages() {
-      this.dialog
-        .open<ConfirmDialogComponent, ConfirmDialogModel, boolean>(
-          ConfirmDialogComponent, {
-            data: {
-              title: 'Delete image',
-              message: 'Are you sure you want to delete these images?'
-            }
-          }
-        )
-        .afterClosed()
-        .pipe(
-          filter((res) => !!res),
-          map(() => this.imagesSelectionService
-            .getSelectedImages()
-            .map((shortToken) => this.imageApi.delete({
-              shortToken: shortToken,
-              manageToken: null
-            }))
-          ),
-          switchMap((requests) => forkJoin(requests)),
-        )
-        .subscribe(() => {
-          this.imagesSelectionService.clearSelection();
-          this.toastr.success('Images were deleted');
-          this.runSearch(PerformType.Search);
-        });
     }
 }
 

--- a/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
+++ b/Client/apps/SdHub/src/app/pages/generated/search-in-images/search-in-images.component.ts
@@ -13,6 +13,7 @@ import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-h
 import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
 import { ToastrService } from "ngx-toastr";
 import { BehaviorSubject, Observable } from "rxjs";
+import { ImageSelectionService } from '../../../core/services/image-selection.service';
 
 @UntilDestroy()
 @Component({
@@ -81,6 +82,7 @@ export class SearchInImagesComponent implements OnInit {
     constructor(
       private imageApi: ImageApi,
       private toastr: ToastrService,
+      private imageSelectionService: ImageSelectionService,
     ) { }
 
     ngOnInit(): void {
@@ -107,6 +109,7 @@ export class SearchInImagesComponent implements OnInit {
             searchText: this.searchText,
         }).subscribe({
             next: resp => {
+                this.imageSelectionService.clearSelection();
                 this.loading = false;
                 this.searchResult$.next(resp);
                 this.totalPages = Math.floor(resp.total / this.pageSize) + ((resp.total % this.pageSize) === 0 ? 0 : 1);

--- a/Client/apps/SdHub/src/app/pages/user/add-album-dialog/add-album-dialog.component.ts
+++ b/Client/apps/SdHub/src/app/pages/user/add-album-dialog/add-album-dialog.component.ts
@@ -1,12 +1,13 @@
-import {Component, Inject, OnInit} from '@angular/core';
-import {AbstractControl, FormBuilder, FormGroup, Validators} from "@angular/forms";
-import {getErrorMessage} from '../../../shared/form-error-handling/handlers';
-import {HttpErrorResponse} from "@angular/common/http";
-import {httpErrorResponseHandler} from "apps/SdHub/src/app/shared/http-error-handling/handlers";
-import {IAlbumModel, ICreateAlbumRequest} from "apps/SdHub/src/app/models/autogen/album.models";
-import {AlbumApi} from "apps/SdHub/src/app/shared/services/api/album.api";
-import {ToastrService} from "ngx-toastr";
-import {MAT_DIALOG_DATA, MatDialog, MatDialogConfig, MatDialogRef} from "@angular/material/dialog";
+import { HttpErrorResponse } from "@angular/common/http";
+import { Component, Inject, OnInit } from '@angular/core';
+import { AbstractControl, FormBuilder, FormGroup, Validators } from "@angular/forms";
+import { MatDialog, MatDialogConfig, MatDialogRef, MAT_DIALOG_DATA } from "@angular/material/dialog";
+import { IAlbumModel, ICreateAlbumRequest } from "apps/SdHub/src/app/models/autogen/album.models";
+import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
+import { AlbumApi } from "apps/SdHub/src/app/shared/services/api/album.api";
+import { ToastrService } from "ngx-toastr";
+import { MyAlbumsService } from '../../../core/services/my-albums.service';
+import { getErrorMessage } from '../../../shared/form-error-handling/handlers';
 
 export interface IAddAlbumDialogData {
 
@@ -27,6 +28,7 @@ export class AddAlbumDialogComponent implements OnInit {
 
     constructor(private formBuilder: FormBuilder,
                 private albumApi: AlbumApi,
+                private myAlbumsService: MyAlbumsService,
                 private toastr: ToastrService,
                 public dialogRef: MatDialogRef<AddAlbumDialogComponent, IAddAlbumDialogResult>,
                 @Inject(MAT_DIALOG_DATA) public data: IAddAlbumDialogData) {
@@ -56,6 +58,7 @@ export class AddAlbumDialogComponent implements OnInit {
         this.albumApi.create(req).subscribe({
             next: x => {
                 this.loading = false;
+                this.myAlbumsService.reloadAlbums();
                 this.toastr.success('Album created');
                 this.dialogRef.close({createdAlbum: x});
             },

--- a/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.html
+++ b/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.html
@@ -4,6 +4,7 @@
   <div>Nothing found ＞︿＜</div>
 </div>
 <image-bunch-actions-panel
+  class="actions-panel"
   [displayedImages]="searchImagesResult?.images ?? []"
   (needReloadImages)="onReloadImages()">
 </image-bunch-actions-panel>
@@ -17,7 +18,10 @@
 <div *ngIf="(searchImagesResult?.total ?? 0) > 0 && !loading"
      class="search-result-container">
   <div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: .5rem">
-    <small-image-card *ngFor="let img of searchImagesResult?.images ?? []" [imageInfo]="img">
+    <small-image-card
+      *ngFor="let img of searchImagesResult?.images ?? []"
+      [imageInfo]="img"
+      (needReloadImages)="onReloadImages()">
     </small-image-card>
   </div>
   <div style="flex-grow: 1"></div>

--- a/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.html
+++ b/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.html
@@ -1,10 +1,8 @@
-<div #scrollTo></div>
 <div *ngIf="(searchImagesResult?.total ?? 0) === 0 && !loading"
      class="search-result-placeholder-container">
   <div>Nothing found ＞︿＜</div>
 </div>
 <image-bunch-actions-panel
-  class="actions-panel"
   [displayedImages]="searchImagesResult?.images ?? []"
   (needReloadImages)="onReloadImages()">
 </image-bunch-actions-panel>
@@ -17,6 +15,7 @@
 </div>
 <div *ngIf="(searchImagesResult?.total ?? 0) > 0 && !loading"
      class="search-result-container">
+  <div #scrollTo></div>
   <div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: .5rem">
     <small-image-card
       *ngFor="let img of searchImagesResult?.images ?? []"

--- a/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.html
+++ b/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.html
@@ -3,6 +3,10 @@
      class="search-result-placeholder-container">
   <div>Nothing found ＞︿＜</div>
 </div>
+<image-bunch-actions-panel
+  [displayedImages]="searchImagesResult?.images ?? []"
+  (needReloadImages)="onReloadImages()">
+</image-bunch-actions-panel>
 <div *ngIf="loading"
      class="search-result-placeholder-container">
   <div style="display: flex; flex-direction: column">

--- a/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.scss
+++ b/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.scss
@@ -15,3 +15,8 @@
   font-size: 4rem;
   gap: .8rem;
 }
+
+.actions-panel {
+  margin-bottom: 0px;
+  display: block;
+}

--- a/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.scss
+++ b/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.scss
@@ -15,8 +15,3 @@
   font-size: 4rem;
   gap: .8rem;
 }
-
-.actions-panel {
-  margin-bottom: 0px;
-  display: block;
-}

--- a/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.ts
+++ b/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.ts
@@ -9,6 +9,7 @@ import { PerformType } from "apps/SdHub/src/app/pages/generated/search-page/sear
 import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
 import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
 import { ToastrService } from "ngx-toastr";
+import { ImageSelectionService } from '../../../core/services/image-selection.service';
 
 @Component({
     selector: 'user-images',
@@ -38,9 +39,11 @@ export class UserImagesComponent implements OnInit {
     public totalPages = 1;
     public loading: boolean = false;
 
-    constructor(private imageApi: ImageApi,
-                private toastr: ToastrService,) {
-    }
+    constructor(
+      private imageApi: ImageApi,
+      private toastr: ToastrService,
+      private imageSelectionService: ImageSelectionService,
+    ) {}
 
     ngOnInit(): void {
     }
@@ -71,6 +74,7 @@ export class UserImagesComponent implements OnInit {
             fields: []
         }).subscribe({
             next: resp => {
+                this.imageSelectionService.clearSelection();
                 this.loading = false;
                 this.searchImagesResult = resp;
                 this.totalPages = Math.floor(resp.total / this.pageSize) + ((resp.total % this.pageSize) === 0 ? 0 : 1);

--- a/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.ts
+++ b/Client/apps/SdHub/src/app/pages/user/user-images/user-images.component.ts
@@ -1,14 +1,14 @@
-import {Component, ElementRef, Input, OnInit, ViewChild} from '@angular/core';
+import { HttpErrorResponse } from "@angular/common/http";
+import { Component, ElementRef, Input, OnInit, ViewChild } from '@angular/core';
 import {
-    ISearchImageResponse,
-    SearchImageOrderByFieldType,
-    SearchImageOrderByType
+  ISearchImageResponse,
+  SearchImageOrderByFieldType,
+  SearchImageOrderByType
 } from "apps/SdHub/src/app/models/autogen/image.models";
-import {HttpErrorResponse} from "@angular/common/http";
-import {httpErrorResponseHandler} from "apps/SdHub/src/app/shared/http-error-handling/handlers";
-import {ImageApi} from "apps/SdHub/src/app/shared/services/api/image.api";
-import {ToastrService} from "ngx-toastr";
-import {PerformType} from "apps/SdHub/src/app/pages/generated/search-page/search-page.component";
+import { PerformType } from "apps/SdHub/src/app/pages/generated/search-page/search-page.component";
+import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
+import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
+import { ToastrService } from "ngx-toastr";
 
 @Component({
     selector: 'user-images',
@@ -47,6 +47,10 @@ export class UserImagesComponent implements OnInit {
 
     public onPageChange(): void {
         this.runImageSearch(PerformType.Pagination);
+    }
+
+    public onReloadImages(): void {
+      this.runImageSearch(PerformType.Search);
     }
 
     private runImageSearch(type: PerformType): void {

--- a/Client/apps/SdHub/src/app/pages/user/user-page/user-page.component.html
+++ b/Client/apps/SdHub/src/app/pages/user/user-page/user-page.component.html
@@ -1,4 +1,4 @@
-<div class="container" fxLayout="row" fxLayoutAlign="center none" style="overflow: auto">
+<div class="container" fxLayout="row" fxLayoutAlign="center none">
   <div fxFlex="100%" style="display: flex; flex-direction: column; gap: .6rem">
     <mat-card>
       <mat-card-content style="display: flex; flex-direction: column;">

--- a/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.html
@@ -41,11 +41,15 @@
   </mat-menu>
 
   <mat-menu #ownAlbumMenu="matMenu">
-    <button mat-menu-item [matMenuTriggerFor]="addToAnotherAlbumMenu">
+    <button mat-menu-item
+            [matMenuTriggerFor]="addToAnotherAlbumMenu"
+            [disabled]="(myAlbumsWithoutCurrent$ | async)!.length === 0">
       <mat-icon>add</mat-icon>
       <span>Add to another</span>
     </button>
-    <button mat-menu-item [matMenuTriggerFor]="moveToAnotherAlbumMenu">
+    <button mat-menu-item
+            [matMenuTriggerFor]="moveToAnotherAlbumMenu"
+            [disabled]="(myAlbumsWithoutCurrent$ | async)!.length === 0">
       <mat-icon>copy_all</mat-icon>
       <span>Move to another</span>
     </button>

--- a/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.html
@@ -1,0 +1,77 @@
+<div class="actions"
+  [class.actions_visible]="hasSelectedImages$ | async"
+  [class.actions_unavailable]="areActionsUnavailable$ | async">
+  <button mat-raised-button (click)="cancelSelection()">
+    <mat-icon>highlight_off</mat-icon>
+    <span>Cancel selection</span>
+  </button>
+  <button
+    *ngIf="(hasAlbums$ | async) && !(isOwnAlbumOpened$ | async)"
+    mat-raised-button color="primary"
+    [matMenuTriggerFor]="addToAlbumMenu">
+    <mat-icon>photo_library</mat-icon>
+    <span>Add to album</span>
+  </button>
+  <button
+    *ngIf="(isOwnAlbumOpened$ | async)"
+    mat-raised-button
+    color="primary"
+    [matMenuTriggerFor]="ownAlbumMenu">
+    <mat-icon>photo_library</mat-icon>
+    <span>Albums</span>
+  </button>
+
+  <button
+    mat-raised-button
+    color="warn"
+    (click)="deleteSelectedImages()"
+    [disabled]="!(canDeleteImages$ | async)">
+    <mat-icon>delete</mat-icon>
+    <span>Delete</span>
+  </button>
+
+  <mat-menu #addToAlbumMenu="matMenu">
+    <button
+      *ngFor="let album of myAlbums$ | async"
+      mat-menu-item
+      (click)="addSelectedImagesToAlbum(album.shortToken)">
+      <mat-icon>photo_library</mat-icon>
+      <span>{{ album.name }}</span>
+    </button>
+  </mat-menu>
+
+  <mat-menu #ownAlbumMenu="matMenu">
+    <button mat-menu-item [matMenuTriggerFor]="addToAnotherAlbumMenu">
+      <mat-icon>add</mat-icon>
+      <span>Add to another</span>
+    </button>
+    <button mat-menu-item [matMenuTriggerFor]="moveToAnotherAlbumMenu">
+      <mat-icon>copy_all</mat-icon>
+      <span>Move to another</span>
+    </button>
+    <button mat-menu-item (click)="deleteSelectedImagesFromCurrentAlbum()">
+      <mat-icon>clear</mat-icon>
+      <span>Delete from current</span>
+    </button>
+  </mat-menu>
+
+  <mat-menu #addToAnotherAlbumMenu="matMenu">
+    <button
+      *ngFor="let album of myAlbumsWithoutCurrent$ | async"
+      mat-menu-item
+      (click)="addSelectedImagesToAlbum(album.shortToken)">
+      <mat-icon>photo_library</mat-icon>
+      <span>{{ album.name }}</span>
+    </button>
+  </mat-menu>
+
+  <mat-menu #moveToAnotherAlbumMenu="matMenu">
+    <button
+      *ngFor="let album of myAlbumsWithoutCurrent$ | async"
+      mat-menu-item
+      (click)="moveSelectedImagesToAnotherAlbum(album.shortToken)">
+      <mat-icon>photo_library</mat-icon>
+      <span>{{ album.name }}</span>
+    </button>
+  </mat-menu>
+</div>

--- a/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.scss
+++ b/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.scss
@@ -1,11 +1,16 @@
-.actions {
+:host {
   position: sticky;
-  top: 15px;
+  top: 0;
+  z-index: 2;
+  margin: -0.5rem 0 -0.5rem;
+}
+
+.actions {
   display: flex;
   gap: 10px;
-  z-index: 2;
   visibility: hidden;
-
+  padding: 10px 0 10px;
+  background: rgb(229, 229, 229);
   // margin-bottom: 10px; // ??
 
   &_visible {
@@ -15,4 +20,8 @@
   &_unavailable {
     display: none;
   }
+}
+
+button .mat-icon {
+  margin-right: 5px;
 }

--- a/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.scss
+++ b/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.scss
@@ -1,17 +1,18 @@
 :host {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  margin: -0.5rem 0 -0.5rem;
+  display: contents;
 }
 
 .actions {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+
   display: flex;
   gap: 10px;
   visibility: hidden;
   padding: 10px 0 10px;
+  margin: -5px 0 -5px;
   background: rgb(229, 229, 229);
-  // margin-bottom: 10px; // ??
 
   &_visible {
     visibility: visible;
@@ -19,6 +20,7 @@
 
   &_unavailable {
     display: none;
+    margin: 0;
   }
 }
 

--- a/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.scss
+++ b/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.scss
@@ -1,0 +1,18 @@
+.actions {
+  position: sticky;
+  top: 15px;
+  display: flex;
+  gap: 10px;
+  z-index: 2;
+  visibility: hidden;
+
+  // margin-bottom: 10px; // ??
+
+  &_visible {
+    visibility: visible;
+  }
+
+  &_unavailable {
+    display: none;
+  }
+}

--- a/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.ts
+++ b/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.ts
@@ -3,7 +3,7 @@ import { IAlbumModel } from "apps/SdHub/src/app/models/autogen/album.models";
 import { keyBy } from 'lodash';
 import { ToastrService } from 'ngx-toastr';
 import { BehaviorSubject, combineLatest, forkJoin } from 'rxjs';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 import { IImageModel } from '../../../models/autogen/misc.models';
 
 import { MatDialog } from '@angular/material/dialog';
@@ -11,8 +11,12 @@ import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
 import { AuthStateService } from '../../../core/services/auth-state.service';
 import { ImageSelectionService } from '../../../core/services/image-selection.service';
 import { MyAlbumsService } from '../../../core/services/my-albums.service';
-import { ConfirmDialogComponent, ConfirmDialogModel } from '../../../shared/components/confirm-dialog/confirm-dialog.component';
+import {
+  ConfirmDialogComponent,
+  ConfirmDialogModel
+} from '../../../shared/components/confirm-dialog/confirm-dialog.component';
 import { AlbumApi } from '../../services/api/album.api';
+import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
 
 @Component({
   selector: 'image-bunch-actions-panel',
@@ -95,7 +99,8 @@ export class ImageBunchActionsPanelComponent implements OnDestroy {
     private myAlbumsService: MyAlbumsService,
     private authStateService: AuthStateService,
     private imageSelectionService: ImageSelectionService,
-  ) {}
+  ) {
+  }
 
   public ngOnDestroy() {
     this.imageSelectionService.clearSelection();
@@ -114,7 +119,7 @@ export class ImageBunchActionsPanelComponent implements OnDestroy {
       .subscribe(() => {
         this.imageSelectionService.clearSelection();
         this.toastr.success('Images were added to the album');
-      });
+      }, err => httpErrorResponseHandler(err, this.toastr));
   }
 
   public moveSelectedImagesToAnotherAlbum(albumShortToken: string) {
@@ -138,7 +143,7 @@ export class ImageBunchActionsPanelComponent implements OnDestroy {
       .subscribe(() => {
         this.toastr.success('Images were moved to another album');
         this.needReloadImages.emit();
-      });
+      }, err => httpErrorResponseHandler(err, this.toastr));
   }
 
   public deleteSelectedImagesFromCurrentAlbum() {
@@ -153,18 +158,18 @@ export class ImageBunchActionsPanelComponent implements OnDestroy {
       .subscribe(() => {
         this.toastr.success('Images were deleted from the album');
         this.needReloadImages.emit();
-      });
+      }, err => httpErrorResponseHandler(err, this.toastr));
   }
 
   public deleteSelectedImages() {
     this.dialog
       .open<ConfirmDialogComponent, ConfirmDialogModel, boolean>(
         ConfirmDialogComponent, {
-        data: {
-          title: 'Delete images',
-          message: 'Are you sure you want to delete these images?'
+          data: {
+            title: 'Delete images',
+            message: 'Are you sure you want to delete these images?'
+          }
         }
-      }
       )
       .afterClosed()
       .pipe(
@@ -181,6 +186,6 @@ export class ImageBunchActionsPanelComponent implements OnDestroy {
       .subscribe(() => {
         this.toastr.success('Images were deleted');
         this.needReloadImages.emit();
-      });
+      }, err => httpErrorResponseHandler(err, this.toastr));
   }
 }

--- a/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.ts
+++ b/Client/apps/SdHub/src/app/shared/components/image-bunch-actions-panel/image-bunch-actions-panel.component.ts
@@ -1,0 +1,192 @@
+import { Component, EventEmitter, Input, OnDestroy, Output } from '@angular/core';
+import { IAlbumModel } from "apps/SdHub/src/app/models/autogen/album.models";
+import { keyBy } from 'lodash';
+import { ToastrService } from 'ngx-toastr';
+import { BehaviorSubject, combineLatest, forkJoin } from 'rxjs';
+import { filter, map, switchMap } from 'rxjs/operators';
+import { IImageModel } from '../../../models/autogen/misc.models';
+
+import { MatDialog } from '@angular/material/dialog';
+import { ImageApi } from "apps/SdHub/src/app/shared/services/api/image.api";
+import { AuthStateService } from '../../../core/services/auth-state.service';
+import { ImageSelectionService } from '../../../core/services/image-selection.service';
+import { MyAlbumsService } from '../../../core/services/my-albums.service';
+import { ConfirmDialogComponent, ConfirmDialogModel } from '../../../shared/components/confirm-dialog/confirm-dialog.component';
+import { AlbumApi } from '../../services/api/album.api';
+
+@Component({
+  selector: 'image-bunch-actions-panel',
+  templateUrl: './image-bunch-actions-panel.component.html',
+  styleUrls: ['./image-bunch-actions-panel.component.scss'],
+})
+export class ImageBunchActionsPanelComponent implements OnDestroy {
+  @Input() set displayedImages(val: IImageModel[]) {
+    this.displayedImages$.next(val);
+  }
+
+  @Input() set selectedAlbum(val: IAlbumModel | null) {
+    this.selectedAlbum$.next(val);
+  }
+
+  @Output() needReloadImages = new EventEmitter();
+
+  private displayedImages$ = new BehaviorSubject<IImageModel[]>([]);
+
+  private selectedAlbum$ = new BehaviorSubject<IAlbumModel | null>(null);
+
+  public myAlbums$ = this.myAlbumsService.myAlbums$;
+
+  public hasAlbums$ = this.myAlbumsService.hasAlbums$;
+
+  public myAlbumsWithoutCurrent$ = combineLatest([this.myAlbums$, this.selectedAlbum$]).pipe(
+    map(([myAlbums, selectedAlbum]) =>
+      myAlbums.filter((album) => album.shortToken !== selectedAlbum?.shortToken)
+    )
+  );
+
+  private displayedImagesByShortToken$ = this.displayedImages$.pipe(
+    map((displayedImages) =>
+      keyBy(displayedImages, (img) => img.shortToken)
+    )
+  );
+
+  public isOwnAlbumOpened$ = combineLatest([
+    this.authStateService.user$,
+    this.selectedAlbum$
+  ]).pipe(
+    map(([user, selectedAlbum]) => {
+      if (!user || !selectedAlbum) {
+        return false;
+      }
+
+      return selectedAlbum.owner.login === user.login;
+    })
+  );
+
+  public areActionsUnavailable$ = this.authStateService.user$.pipe(
+    map((user) => !user)
+  );
+
+  public canDeleteImages$ = combineLatest([
+    this.authStateService.user$,
+    this.displayedImagesByShortToken$,
+    this.imagesSelectionService.selectedImages$
+  ]).pipe(
+    map(([user, displayedImagesByShortToken, selectedImages]) => {
+      if (!user) {
+        return false;
+      }
+
+      return selectedImages
+        .every((shortImageToken) => {
+          const selectedImageInfo = displayedImagesByShortToken[shortImageToken];
+          return selectedImageInfo?.owner?.login === user.login
+        })
+    })
+  );
+
+  public hasSelectedImages$ = this.imagesSelectionService.hasSelectedImages$;
+
+  constructor(
+    private imageApi: ImageApi,
+    private toastr: ToastrService,
+    private albumApi: AlbumApi,
+    private dialog: MatDialog,
+    private myAlbumsService: MyAlbumsService,
+    private authStateService: AuthStateService,
+    private imagesSelectionService: ImageSelectionService,
+  ) {}
+
+  public ngOnDestroy() {
+    this.imagesSelectionService.clearSelection();
+  }
+
+  public cancelSelection() {
+    this.imagesSelectionService.clearSelection();
+  }
+
+  public addSelectedImagesToAlbum(albumShortToken: string) {
+    this.albumApi
+      .addImages({
+        albumShortToken,
+        images: this.imagesSelectionService.getSelectedImages()
+      })
+      .subscribe(() => {
+        this.imagesSelectionService.clearSelection();
+        this.toastr.success('Images were added to the album');
+      });
+  }
+
+  public moveSelectedImagesToAnotherAlbum(albumShortToken: string) {
+    if (!this.selectedAlbum$.value) {
+      return;
+    }
+
+    const deleteImagesFromAlbumRequest$ = this.albumApi
+      .deleteImages({
+        albumShortToken: this.selectedAlbum$.value.shortToken,
+        images: this.imagesSelectionService.getSelectedImages()
+      });
+
+    const addImagesToAlbumRequest$ = this.albumApi
+      .addImages({
+        albumShortToken,
+        images: this.imagesSelectionService.getSelectedImages()
+      });
+
+    combineLatest([deleteImagesFromAlbumRequest$, addImagesToAlbumRequest$])
+      .subscribe(() => {
+        this.imagesSelectionService.clearSelection();
+        this.toastr.success('Images were moved to another album');
+
+        this.needReloadImages.emit();
+      });
+  }
+
+  public deleteSelectedImagesFromCurrentAlbum() {
+    if (!this.selectedAlbum$.value) {
+      return;
+    }
+    this.albumApi
+      .deleteImages({
+        albumShortToken: this.selectedAlbum$.value.shortToken,
+        images: this.imagesSelectionService.getSelectedImages()
+      })
+      .subscribe(() => {
+        this.imagesSelectionService.clearSelection();
+        this.toastr.success('Images were deleted from the album');
+
+        this.needReloadImages.emit();
+      });
+  }
+
+  public deleteSelectedImages() {
+    this.dialog
+      .open<ConfirmDialogComponent, ConfirmDialogModel, boolean>(
+        ConfirmDialogComponent, {
+        data: {
+          title: 'Delete images',
+          message: 'Are you sure you want to delete these images?'
+        }
+      }
+      )
+      .afterClosed()
+      .pipe(
+        filter((res) => !!res),
+        map(() => this.imagesSelectionService
+          .getSelectedImages()
+          .map((shortToken) => this.imageApi.delete({
+            shortToken: shortToken,
+            manageToken: null
+          }))
+        ),
+        switchMap((requests) => forkJoin(requests)),
+      )
+      .subscribe(() => {
+        this.imagesSelectionService.clearSelection();
+        this.toastr.success('Images were deleted');
+
+        this.needReloadImages.emit();
+      });
+  }
+}

--- a/Client/apps/SdHub/src/app/shared/components/layout/layout.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/layout/layout.component.html
@@ -41,10 +41,13 @@
         </a>
 
         <h3 mat-subheader>Models/Vae/...</h3>
-        <a mat-list-item [routerLink]="['/bin/search']" routerLinkActive="active">
-          <mat-icon mat-list-icon>folder_zip</mat-icon>
-          <p mat-line>All</p>
-        </a>
+        <div matTooltip="not implemented"
+             matTooltipPosition="right">
+          <a mat-list-item [routerLink]="['/bin/search']" routerLinkActive="active" disabled>
+            <mat-icon mat-list-icon>folder_zip</mat-icon>
+            <p mat-line>All</p>
+          </a>
+        </div>
 
         <mat-divider></mat-divider>
 

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
@@ -75,11 +75,15 @@
 </mat-menu>
 
 <mat-menu #ownAlbumMenu="matMenu">
-  <button mat-menu-item [matMenuTriggerFor]="addToAnotherAlbumMenu">
+  <button mat-menu-item
+          [matMenuTriggerFor]="addToAnotherAlbumMenu"
+          [disabled]="(myAlbumsWithoutCurrent$ | async)!.length === 0">
     <mat-icon>add</mat-icon>
     <span>Add to another</span>
   </button>
-  <button mat-menu-item [matMenuTriggerFor]="moveToAnotherAlbumMenu">
+  <button mat-menu-item
+          [matMenuTriggerFor]="moveToAnotherAlbumMenu"
+          [disabled]="(myAlbumsWithoutCurrent$ | async)!.length === 0">
     <mat-icon>copy_all</mat-icon>
     <span>Move to another</span>
   </button>

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
@@ -1,4 +1,10 @@
 <mat-card>
+  <div
+    *ngIf="isSelectionModeActivated$ | async"
+    class="image-selection-overlay"
+    [class.image-selection-overlay_selected]="isSelected$ | async"
+    (click)="toggleSelection()">
+  </div>
   <mat-card-content style="display: flex; flex-direction: column; gap: .4rem">
     <a class="card-container">
       <a *ngIf="thumbUrl != ''; else noThumb"
@@ -34,10 +40,10 @@
 </mat-card>
 
 <mat-menu #cardMenu="matMenu">
-  <!-- <button mat-menu-item>
+  <button mat-menu-item (click)="toggleSelection()">
     <mat-icon>library_add_check</mat-icon>
     <span>Begin selection</span>
-  </button> -->
+  </button>
   <button *ngIf="hasAlbums$ | async" mat-menu-item [matMenuTriggerFor]="albumsMenu">
     <mat-icon>photo_library</mat-icon>
     <span>Add to album</span>

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
@@ -1,12 +1,19 @@
 <mat-card>
   <mat-card-content style="display: flex; flex-direction: column; gap: .4rem">
-    <a class="card-container" [routerLink]="'/i/' + shortToken">
+    <a class="card-container">
       <a *ngIf="thumbUrl != ''; else noThumb"
-         [href]="compressedUrl">
+        [routerLink]="'/i/' + shortToken">
         <img class="thumbnail"
              [attr.src]="thumbUrl"
              [attr.data-src]="compressedUrl">
       </a>
+      <button
+        *ngIf="displayMenuButton$ | async"
+        class="menu-button"
+        mat-icon-button
+        [matMenuTriggerFor]="cardMenu">
+        <mat-icon>more_vert</mat-icon>
+      </button>
       <ng-template #noThumb>
         <span style="font-style: italic">Preview not available</span>
       </ng-template>
@@ -25,3 +32,25 @@
     <div>Dims: <span class="gray-value">{{dims}}</span></div>
   </mat-card-content>
 </mat-card>
+
+<mat-menu #cardMenu="matMenu">
+  <!-- <button mat-menu-item>
+    <mat-icon>library_add_check</mat-icon>
+    <span>Begin selection</span>
+  </button> -->
+  <button *ngIf="hasAlbums$ | async" mat-menu-item [matMenuTriggerFor]="albumsMenu">
+    <mat-icon>photo_library</mat-icon>
+    <span>Add to album</span>
+  </button>
+  <button *ngIf="canDelete$ | async" mat-menu-item (click)="deleteImage()">
+    <mat-icon>delete</mat-icon>
+    <span>Delete</span>
+  </button>
+</mat-menu>
+
+<mat-menu #albumsMenu="matMenu">
+  <button *ngFor="let album of myAlbums$ | async" mat-menu-item (click)="addImageToAlbum(album.shortToken)">
+    <mat-icon>photo_library</mat-icon>
+    <span>{{ album.name }}</span>
+  </button>
+</mat-menu>

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
@@ -17,8 +17,10 @@
       <button
         *ngIf="displayMenuButton$ | async"
         class="menu-button"
+        [class.menu-button_opened]="isMenuOpened"
         mat-icon-button
-        [matMenuTriggerFor]="cardMenu">
+        [matMenuTriggerFor]="cardMenu"
+        (click)="onMenuOpened()">
         <mat-icon>more_vert</mat-icon>
       </button>
       <ng-template #noThumb>
@@ -40,7 +42,7 @@
   </mat-card-content>
 </mat-card>
 
-<mat-menu #cardMenu="matMenu">
+<mat-menu #cardMenu="matMenu" (closed)="onMenuClosed()">
   <button mat-menu-item (click)="toggleSelection()">
     <mat-icon>library_add_check</mat-icon>
     <span>Begin selection</span>

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card [class.common-mode]="!(isSelectionModeActivated$ | async)">
   <div
     *ngIf="isSelectionModeActivated$ | async"
     class="image-selection-overlay"

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
@@ -44,18 +44,63 @@
     <mat-icon>library_add_check</mat-icon>
     <span>Begin selection</span>
   </button>
-  <button *ngIf="hasAlbums$ | async" mat-menu-item [matMenuTriggerFor]="albumsMenu">
+  <button
+    *ngIf="(hasAlbums$ | async) && !(isOwnAlbumOpened$ | async)"
+    mat-menu-item
+    [matMenuTriggerFor]="addToAlbumMenu">
     <mat-icon>photo_library</mat-icon>
     <span>Add to album</span>
   </button>
-  <button *ngIf="canDelete$ | async" mat-menu-item (click)="deleteImage()">
+  <button
+    *ngIf="(isOwnAlbumOpened$ | async)"
+    mat-menu-item
+    [matMenuTriggerFor]="ownAlbumMenu">
+    <mat-icon>photo_library</mat-icon>
+    <span>Albums</span>
+  </button>
+  <button *ngIf="canDeleteImage$ | async" mat-menu-item (click)="deleteImage()">
     <mat-icon>delete</mat-icon>
     <span>Delete</span>
   </button>
 </mat-menu>
 
-<mat-menu #albumsMenu="matMenu">
+<mat-menu #addToAlbumMenu="matMenu">
   <button *ngFor="let album of myAlbums$ | async" mat-menu-item (click)="addImageToAlbum(album.shortToken)">
+    <mat-icon>photo_library</mat-icon>
+    <span>{{ album.name }}</span>
+  </button>
+</mat-menu>
+
+<mat-menu #ownAlbumMenu="matMenu">
+  <button mat-menu-item [matMenuTriggerFor]="addToAnotherAlbumMenu">
+    <mat-icon>add</mat-icon>
+    <span>Add to another</span>
+  </button>
+  <button mat-menu-item [matMenuTriggerFor]="moveToAnotherAlbumMenu">
+    <mat-icon>copy_all</mat-icon>
+    <span>Move to another</span>
+  </button>
+  <button mat-menu-item (click)="deleteImageFromCurrentAlbum()">
+    <mat-icon>clear</mat-icon>
+    <span>Delete from current</span>
+  </button>
+</mat-menu>
+
+<mat-menu #addToAnotherAlbumMenu="matMenu">
+  <button
+    *ngFor="let album of myAlbumsWithoutCurrent$ | async"
+    mat-menu-item
+    (click)="addImageToAlbum(album.shortToken)">
+    <mat-icon>photo_library</mat-icon>
+    <span>{{ album.name }}</span>
+  </button>
+</mat-menu>
+
+<mat-menu #moveToAnotherAlbumMenu="matMenu">
+  <button
+    *ngFor="let album of myAlbumsWithoutCurrent$ | async"
+    mat-menu-item
+    (click)="moveImageToAnotherAlbum(album.shortToken)">
     <mat-icon>photo_library</mat-icon>
     <span>{{ album.name }}</span>
   </button>

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.html
@@ -7,11 +7,12 @@
   </div>
   <mat-card-content style="display: flex; flex-direction: column; gap: .4rem">
     <a class="card-container">
-      <a *ngIf="thumbUrl != ''; else noThumb"
-        [routerLink]="'/i/' + shortToken">
-        <img class="thumbnail"
-             [attr.src]="thumbUrl"
-             [attr.data-src]="compressedUrl">
+      <a *ngIf="thumbUrl != ''; else noThumb" [href]="compressedUrl">
+        <a [routerLink]="'/i/' + shortToken">
+          <img class="thumbnail"
+            [attr.src]="thumbUrl"
+            [attr.data-src]="compressedUrl">
+        </a>
       </a>
       <button
         *ngIf="displayMenuButton$ | async"

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
@@ -12,10 +12,17 @@
     max-width: 100%;
     max-height: 100%;
   }
+
+  .menu-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    color: rgba(0, 0, 0, .87);
+    display: block;
+  }
 }
 
-
-.gray-value{
+.gray-value {
   background-color: #ebebeb;
   padding: 0.2rem;
   border-radius: 0.4rem;

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
@@ -18,6 +18,17 @@
     top: 0;
     right: 0;
     color: rgba(0, 0, 0, .87);
+    background: white;
+    display: none;
+
+    &_opened {
+      display: block;
+    }
+  }
+}
+
+:host:hover {
+  .menu-button {
     display: block;
   }
 }

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
@@ -28,3 +28,17 @@
   border-radius: 0.4rem;
   box-sizing: border-box;
 }
+
+.image-selection-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
+  cursor: pointer;
+
+  &_selected {
+    border: #00ff40 solid;
+  }
+}

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.scss
@@ -27,10 +27,8 @@
   }
 }
 
-:host:hover {
-  .menu-button {
-    display: block;
-  }
+:host:hover .common-mode .menu-button {
+  display: block;
 }
 
 .gray-value {

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
@@ -2,9 +2,10 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { IImageModel } from "apps/SdHub/src/app/models/autogen/misc.models";
 import { ToastrService } from 'ngx-toastr';
-import { combineLatest } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { AuthStateService } from '../../../core/services/auth-state.service';
+import { ImageSelectionService } from '../../../core/services/image-selection.service';
 import { MyAlbumsService } from '../../../core/services/my-albums.service';
 import { AlbumApi } from '../../services/api/album.api';
 import { ImageApi } from '../../services/api/image.api';
@@ -50,6 +51,10 @@ export class SmallImageCardComponent implements OnInit {
       map(([hasAlbums, canDelete]) => hasAlbums || canDelete)
     );
 
+    public isSelected$: Observable<boolean> = null!;
+
+    public isSelectionModeActivated$ = this.imageSelectionService.hasSelectedImages$;
+
     constructor(
       private dialog: MatDialog,
       private albumApi: AlbumApi,
@@ -57,9 +62,11 @@ export class SmallImageCardComponent implements OnInit {
       private toastr: ToastrService,
       private authStateService: AuthStateService,
       private myAlbumsService: MyAlbumsService,
+      private imageSelectionService: ImageSelectionService,
     ) { }
 
     ngOnInit(): void {
+      this.isSelected$ = this.imageSelectionService.isSelected(this.shortToken);
     }
 
     public addImageToAlbum(albumShortToken: string) {
@@ -89,6 +96,10 @@ export class SmallImageCardComponent implements OnInit {
           this.toastr.success('Image deleted');
           this.imageDeleted.emit();
         });
+    }
+
+    toggleSelection() {
+      this.imageSelectionService.toggleSelected(this.shortToken);
     }
 
     private loadImage(value: IImageModel | null): void {

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { IImageModel } from "apps/SdHub/src/app/models/autogen/misc.models";
+import { ToastrService } from 'ngx-toastr';
 import { combineLatest } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { AuthStateService } from '../../../core/services/auth-state.service';
@@ -23,6 +24,8 @@ export class SmallImageCardComponent implements OnInit {
         this._imageInfo = value;
         this.loadImage(value);
     }
+
+    @Output() imageDeleted = new EventEmitter();
 
     private _imageInfo: IImageModel | null = null;
 
@@ -51,6 +54,7 @@ export class SmallImageCardComponent implements OnInit {
       private dialog: MatDialog,
       private albumApi: AlbumApi,
       private imageApi: ImageApi,
+      private toastr: ToastrService,
       private authStateService: AuthStateService,
       private myAlbumsService: MyAlbumsService,
     ) { }
@@ -61,7 +65,7 @@ export class SmallImageCardComponent implements OnInit {
     public addImageToAlbum(albumShortToken: string) {
       this.albumApi
         .addImages({ albumShortToken, images: [this.shortToken] })
-        .subscribe();
+        .subscribe(() => this.toastr.success('Image was added to the album'));
     }
 
     public deleteImage() {
@@ -81,7 +85,10 @@ export class SmallImageCardComponent implements OnInit {
             this.imageApi.delete({ shortToken: this.shortToken, manageToken: null })
           )
         )
-        .subscribe();
+        .subscribe(() => {
+          this.toastr.success('Image deleted');
+          this.imageDeleted.emit();
+        });
     }
 
     private loadImage(value: IImageModel | null): void {

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
@@ -11,183 +11,185 @@ import { IAlbumModel } from '../../../models/autogen/album.models';
 import { AlbumApi } from '../../services/api/album.api';
 import { ImageApi } from '../../services/api/image.api';
 import { ConfirmDialogComponent, ConfirmDialogModel } from '../confirm-dialog/confirm-dialog.component';
+import { httpErrorResponseHandler } from "apps/SdHub/src/app/shared/http-error-handling/handlers";
 
 @Component({
-    selector: 'small-image-card',
-    templateUrl: './small-image-card.component.html',
-    styleUrls: ['./small-image-card.component.scss'],
+  selector: 'small-image-card',
+  templateUrl: './small-image-card.component.html',
+  styleUrls: ['./small-image-card.component.scss'],
 })
 export class SmallImageCardComponent implements OnInit {
-    get imageInfo(): IImageModel | null {
-        return this._imageInfo;
+  get imageInfo(): IImageModel | null {
+    return this._imageInfo;
+  }
+
+  @Input() set imageInfo(value: IImageModel | null) {
+    this._imageInfo = value;
+    this.loadImage(value);
+  }
+
+  @Input() set selectedAlbum(val: IAlbumModel | null) {
+    this.selectedAlbum$.next(val);
+  }
+
+  @Output() needReloadImages = new EventEmitter();
+
+  private _imageInfo: IImageModel | null = null;
+
+  public selectedAlbum$ = new BehaviorSubject<IAlbumModel | null>(null);
+
+  public name: string = '';
+  public uploadAt: string = '';
+  public userName: string = '';
+  public software: string = '';
+  public thumbUrl: string = '';
+  public compressedUrl: string = '';
+  public dims: string = '';
+  public shortToken: string = '';
+
+  public isMenuOpened: boolean = false;
+
+  public myAlbums$ = this.myAlbumsService.myAlbums$;
+
+  public hasAlbums$ = this.myAlbumsService.hasAlbums$;
+
+  public myAlbumsWithoutCurrent$ = combineLatest([this.myAlbums$, this.selectedAlbum$]).pipe(
+    map(([myAlbums, selectedAlbum]) =>
+      myAlbums.filter((album) => album.shortToken !== selectedAlbum?.shortToken)
+    )
+  );
+
+  public canDeleteImage$ = this.authStateService.user$.pipe(
+    map((user) => user?.login === this.userName)
+  );
+
+  public displayMenuButton$ = combineLatest([this.hasAlbums$, this.canDeleteImage$]).pipe(
+    map(([hasAlbums, canDelete]) => hasAlbums || canDelete)
+  );
+
+  public isSelected$: Observable<boolean> = null!;
+
+  public isSelectionModeActivated$ = this.imageSelectionService.hasSelectedImages$;
+
+  public isOwnAlbumOpened$ = combineLatest([
+    this.authStateService.user$,
+    this.selectedAlbum$
+  ]).pipe(
+    map(([user, selectedAlbum]) => {
+      if (!user || !selectedAlbum) {
+        return false;
+      }
+
+      return selectedAlbum.owner.login === user.login;
+    })
+  );
+
+  constructor(
+    private dialog: MatDialog,
+    private albumApi: AlbumApi,
+    private imageApi: ImageApi,
+    private toastr: ToastrService,
+    private authStateService: AuthStateService,
+    private myAlbumsService: MyAlbumsService,
+    private imageSelectionService: ImageSelectionService,
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.isSelected$ = this.imageSelectionService.isSelected(this.shortToken);
+  }
+
+  public addImageToAlbum(albumShortToken: string) {
+    this.albumApi
+      .addImages({albumShortToken, images: [this.shortToken]})
+      .subscribe(() => this.toastr.success('Image was added to the album'), err => httpErrorResponseHandler(err, this.toastr));
+  }
+
+  public moveImageToAnotherAlbum(albumShortToken: string) {
+    if (!this.selectedAlbum$.value) {
+      return;
     }
 
-    @Input() set imageInfo(value: IImageModel | null) {
-        this._imageInfo = value;
-        this.loadImage(value);
+    const deleteImageFromAlbumRequest$ = this.albumApi
+      .deleteImages({
+        albumShortToken: this.selectedAlbum$.value.shortToken,
+        images: [this.shortToken]
+      });
+
+    const addImageToAlbumRequest$ = this.albumApi
+      .addImages({
+        albumShortToken,
+        images: [this.shortToken]
+      });
+
+    combineLatest([deleteImageFromAlbumRequest$, addImageToAlbumRequest$])
+      .subscribe(() => {
+        this.toastr.success('Image was moved to another album');
+        this.needReloadImages.emit();
+      }, err => httpErrorResponseHandler(err, this.toastr));
+  }
+
+  public deleteImageFromCurrentAlbum() {
+    if (!this.selectedAlbum$.value) {
+      return;
     }
 
-    @Input() set selectedAlbum(val: IAlbumModel | null) {
-      this.selectedAlbum$.next(val);
-    }
-
-    @Output() needReloadImages = new EventEmitter();
-
-    private _imageInfo: IImageModel | null = null;
-
-    public selectedAlbum$ = new BehaviorSubject<IAlbumModel | null>(null);
-
-    public name: string = '';
-    public uploadAt: string = '';
-    public userName: string = '';
-    public software: string = '';
-    public thumbUrl: string = '';
-    public compressedUrl: string = '';
-    public dims: string = '';
-    public shortToken: string = '';
-
-    public isMenuOpened: boolean = false;
-
-    public myAlbums$ = this.myAlbumsService.myAlbums$;
-
-    public hasAlbums$ = this.myAlbumsService.hasAlbums$;
-
-    public myAlbumsWithoutCurrent$ = combineLatest([this.myAlbums$, this.selectedAlbum$]).pipe(
-      map(([myAlbums, selectedAlbum]) =>
-        myAlbums.filter((album) => album.shortToken !== selectedAlbum?.shortToken)
-      )
-    );
-
-    public canDeleteImage$ = this.authStateService.user$.pipe(
-      map((user) => user?.login === this.userName)
-    );
-
-    public displayMenuButton$ = combineLatest([this.hasAlbums$, this.canDeleteImage$]).pipe(
-      map(([hasAlbums, canDelete]) => hasAlbums || canDelete)
-    );
-
-    public isSelected$: Observable<boolean> = null!;
-
-    public isSelectionModeActivated$ = this.imageSelectionService.hasSelectedImages$;
-
-    public isOwnAlbumOpened$ = combineLatest([
-      this.authStateService.user$,
-      this.selectedAlbum$
-    ]).pipe(
-      map(([user, selectedAlbum]) => {
-        if (!user || !selectedAlbum) {
-          return false;
-        }
-
-        return selectedAlbum.owner.login === user.login;
+    this.albumApi
+      .deleteImages({
+        albumShortToken: this.selectedAlbum$.value.shortToken,
+        images: [this.shortToken]
       })
-    );
+      .subscribe(() => {
+        this.toastr.success('Image was deleted from the album');
+        this.needReloadImages.emit();
+      }, err => httpErrorResponseHandler(err, this.toastr));
+  }
 
-    constructor(
-      private dialog: MatDialog,
-      private albumApi: AlbumApi,
-      private imageApi: ImageApi,
-      private toastr: ToastrService,
-      private authStateService: AuthStateService,
-      private myAlbumsService: MyAlbumsService,
-      private imageSelectionService: ImageSelectionService,
-    ) { }
-
-    ngOnInit(): void {
-      this.isSelected$ = this.imageSelectionService.isSelected(this.shortToken);
-    }
-
-    public addImageToAlbum(albumShortToken: string) {
-      this.albumApi
-        .addImages({ albumShortToken, images: [this.shortToken] })
-        .subscribe(() => this.toastr.success('Image was added to the album'));
-    }
-
-    public moveImageToAnotherAlbum(albumShortToken: string) {
-      if (!this.selectedAlbum$.value) {
-        return;
-      }
-
-      const deleteImageFromAlbumRequest$ = this.albumApi
-        .deleteImages({
-          albumShortToken: this.selectedAlbum$.value.shortToken,
-          images: [this.shortToken]
-        });
-
-      const addImageToAlbumRequest$ = this.albumApi
-        .addImages({
-          albumShortToken,
-          images: [this.shortToken]
-        });
-
-      combineLatest([deleteImageFromAlbumRequest$, addImageToAlbumRequest$])
-        .subscribe(() => {
-          this.toastr.success('Image was moved to another album');
-          this.needReloadImages.emit();
-        });
-    }
-
-    public deleteImageFromCurrentAlbum() {
-      if (!this.selectedAlbum$.value) {
-        return;
-      }
-
-      this.albumApi
-        .deleteImages({
-          albumShortToken: this.selectedAlbum$.value.shortToken,
-          images: [this.shortToken]
-        })
-        .subscribe(() => {
-          this.toastr.success('Image was deleted from the album');
-          this.needReloadImages.emit();
-        });
-    }
-
-    public deleteImage() {
-      this.dialog
-        .open<ConfirmDialogComponent, ConfirmDialogModel, boolean>(
-          ConfirmDialogComponent, {
-            data: {
-              title: 'Delete image',
-              message: 'Are you sure you want to delete this image?'
-            }
+  public deleteImage() {
+    this.dialog
+      .open<ConfirmDialogComponent, ConfirmDialogModel, boolean>(
+        ConfirmDialogComponent, {
+          data: {
+            title: 'Delete image',
+            message: 'Are you sure you want to delete this image?'
           }
+        }
+      )
+      .afterClosed()
+      .pipe(
+        filter((res) => !!res),
+        switchMap(() =>
+          this.imageApi.delete({shortToken: this.shortToken, manageToken: null})
         )
-        .afterClosed()
-        .pipe(
-          filter((res) => !!res),
-          switchMap(() =>
-            this.imageApi.delete({ shortToken: this.shortToken, manageToken: null })
-          )
-        )
-        .subscribe(() => {
-          this.toastr.success('Image deleted');
-          this.needReloadImages.emit();
-        });
-    }
+      )
+      .subscribe(() => {
+        this.toastr.success('Image deleted');
+        this.needReloadImages.emit();
+      }, err => httpErrorResponseHandler(err, this.toastr));
+  }
 
-    public toggleSelection() {
-      this.imageSelectionService.toggleSelected(this.shortToken);
-    }
+  public toggleSelection() {
+    this.imageSelectionService.toggleSelected(this.shortToken);
+  }
 
-    public onMenuOpened() {
-      this.isMenuOpened = true;
-    }
+  public onMenuOpened() {
+    this.isMenuOpened = true;
+  }
 
-    public onMenuClosed() {
-      this.isMenuOpened = false;
-    }
+  public onMenuClosed() {
+    this.isMenuOpened = false;
+  }
 
-    private loadImage(value: IImageModel | null): void {
-        this.name = value?.name ?? '';
-        this.uploadAt = value?.createdAt ?? '';
-        this.userName = value?.owner?.login ?? '';
-        this.software = value?.parsedMetadata?.tags?.[0]?.software ?? 'unknown';
-        this.thumbUrl = value?.thumbImage?.directUrl ?? '';
-        this.compressedUrl = value?.compressedImage?.directUrl ?? '';
-        this.dims = value?.parsedMetadata?.width != null && value?.parsedMetadata?.height != null
-            ? `${value?.parsedMetadata?.width}x${value?.parsedMetadata?.height}`
-            : '';
-        this.shortToken = value?.shortToken ?? '';
-    }
+  private loadImage(value: IImageModel | null): void {
+    this.name = value?.name ?? '';
+    this.uploadAt = value?.createdAt ?? '';
+    this.userName = value?.owner?.login ?? '';
+    this.software = value?.parsedMetadata?.tags?.[0]?.software ?? 'unknown';
+    this.thumbUrl = value?.thumbImage?.directUrl ?? '';
+    this.compressedUrl = value?.compressedImage?.directUrl ?? '';
+    this.dims = value?.parsedMetadata?.width != null && value?.parsedMetadata?.height != null
+      ? `${value?.parsedMetadata?.width}x${value?.parsedMetadata?.height}`
+      : '';
+    this.shortToken = value?.shortToken ?? '';
+  }
 }

--- a/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
+++ b/Client/apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component.ts
@@ -46,6 +46,8 @@ export class SmallImageCardComponent implements OnInit {
     public dims: string = '';
     public shortToken: string = '';
 
+    public isMenuOpened: boolean = false;
+
     public myAlbums$ = this.myAlbumsService.myAlbums$;
 
     public hasAlbums$ = this.myAlbumsService.hasAlbums$;
@@ -164,8 +166,16 @@ export class SmallImageCardComponent implements OnInit {
         });
     }
 
-    toggleSelection() {
+    public toggleSelection() {
       this.imageSelectionService.toggleSelected(this.shortToken);
+    }
+
+    public onMenuOpened() {
+      this.isMenuOpened = true;
+    }
+
+    public onMenuClosed() {
+      this.isMenuOpened = false;
     }
 
     private loadImage(value: IImageModel | null): void {

--- a/Client/apps/SdHub/src/app/shared/shared.module.ts
+++ b/Client/apps/SdHub/src/app/shared/shared.module.ts
@@ -1,27 +1,28 @@
-import {NgModule} from '@angular/core';
-import {RouterModule} from '@angular/router';
-import {FlexLayoutModule} from '@angular/flex-layout';
-import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
 
-import {LimitToPipe} from './pipes/limit-to.pipe';
-import {ConfirmDialogComponent} from './components/confirm-dialog/confirm-dialog.component';
-import {LocalDatePipe} from './pipes/local-date.pipe';
-import {YesNoPipe} from './pipes/yes-no.pipe';
-import {LayoutComponent} from './components/layout/layout.component';
-import {CustomMaterialModule} from '../custom-material/custom-material.module';
-import {OverlayModule} from '@angular/cdk/overlay';
-import {A11yModule} from '@angular/cdk/a11y';
-import {PaginatorComponent} from './components/paginator/paginator.component';
+import { A11yModule } from '@angular/cdk/a11y';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { LeafletModule } from "@asymmetrik/ngx-leaflet";
+import { GridViewerComponent } from "apps/SdHub/src/app/shared/components/grid-viewer/grid-viewer.component";
 import {
-    SmallImageCardComponent
-} from 'apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component';
-import {ImageViewerComponent} from './components/image-viewer/image-viewer.component';
-import {ImageViewerDialogComponent} from './components/image-viewer-dialog/image-viewer-dialog.component';
-import {LeafletModule} from "@asymmetrik/ngx-leaflet";
-import {GridViewerComponent} from "apps/SdHub/src/app/shared/components/grid-viewer/grid-viewer.component";
-import {
-    SmallAlbumCardComponent
+  SmallAlbumCardComponent
 } from "apps/SdHub/src/app/shared/components/small-album-card/small-album-card.component";
+import {
+  SmallImageCardComponent
+} from 'apps/SdHub/src/app/shared/components/small-image-card/small-image-card.component';
+import { CustomMaterialModule } from '../custom-material/custom-material.module';
+import { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dialog.component';
+import { ImageBunchActionsPanelComponent } from './components/image-bunch-actions-panel/image-bunch-actions-panel.component';
+import { ImageViewerDialogComponent } from './components/image-viewer-dialog/image-viewer-dialog.component';
+import { ImageViewerComponent } from './components/image-viewer/image-viewer.component';
+import { LayoutComponent } from './components/layout/layout.component';
+import { PaginatorComponent } from './components/paginator/paginator.component';
+import { LimitToPipe } from './pipes/limit-to.pipe';
+import { LocalDatePipe } from './pipes/local-date.pipe';
+import { YesNoPipe } from './pipes/yes-no.pipe';
 
 @NgModule({
     imports: [
@@ -45,6 +46,7 @@ import {
         PaginatorComponent,
         ImageViewerComponent,
         GridViewerComponent,
+        ImageBunchActionsPanelComponent,
         ImageViewerDialogComponent,
     ],
     exports: [
@@ -59,6 +61,7 @@ import {
         LocalDatePipe,
         YesNoPipe,
         GridViewerComponent,
+        ImageBunchActionsPanelComponent,
         PaginatorComponent,
     ],
 })

--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -43,6 +43,7 @@
         "@nrwl/workspace": "15.0.4",
         "@types/jasmine": "~4.0.0",
         "@types/leaflet": "^1.9.0",
+        "@types/lodash": "^4.14.191",
         "@types/marked": "^4.0.7",
         "jasmine-core": "~4.3.0",
         "karma": "~6.4.0",
@@ -7453,6 +7454,12 @@
       "dependencies": {
         "@types/geojson": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "node_modules/@types/marked": {
       "version": "4.0.7",
@@ -26874,6 +26881,12 @@
       "requires": {
         "@types/geojson": "*"
       }
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "@types/marked": {
       "version": "4.0.7",

--- a/Client/package.json
+++ b/Client/package.json
@@ -45,6 +45,7 @@
     "@nrwl/workspace": "15.0.4",
     "@types/jasmine": "~4.0.0",
     "@types/leaflet": "^1.9.0",
+    "@types/lodash": "^4.14.191",
     "@types/marked": "^4.0.7",
     "jasmine-core": "~4.3.0",
     "karma": "~6.4.0",

--- a/Server/SdHub/Controllers/AlbumController.cs
+++ b/Server/SdHub/Controllers/AlbumController.cs
@@ -91,11 +91,20 @@ public class AlbumController : ControllerBase
         }
 
         query = query
+            .Include(x => x.AlbumImages!.Take(1)).ThenInclude(x => x.Image).ThenInclude(x => x!.CompressedImage)
             .Include(x => x.ThumbImage)
             .Include(x => x.Owner)
             .Where(x => x.DeletedAt == null);
         var total = await query.CountAsync(ct);
         var albums = await query.Skip(req.Skip).Take(req.Take).ToArrayAsync(ct);
+        foreach (var albumEntity in albums)
+        {
+            if (albumEntity.AlbumImages?.Count > 0)
+            {
+                albumEntity.ThumbImage = albumEntity.AlbumImages[0].Image?.CompressedImage;
+            }
+        }
+
         var albumModels = _mapper.Map<AlbumModel[]>(albums);
 
         return new SearchAlbumResponse()

--- a/Server/SdHub/Models/Image/DeleteImageRequest.cs
+++ b/Server/SdHub/Models/Image/DeleteImageRequest.cs
@@ -6,6 +6,6 @@ public class DeleteImageRequest
 {
     public string? ShortToken { get; set; }
 
-    [TsProperty(ForceNullable = true)]
+    [TsProperty(Type = "string | null")]
     public string? ManageToken { get; set; }
 }

--- a/Server/SdHub/Models/Image/DeleteImageRequest.cs
+++ b/Server/SdHub/Models/Image/DeleteImageRequest.cs
@@ -1,7 +1,11 @@
-﻿namespace SdHub.Models.Image;
+﻿using Reinforced.Typings.Attributes;
+
+namespace SdHub.Models.Image;
 
 public class DeleteImageRequest
 {
     public string? ShortToken { get; set; }
+
+    [TsProperty(ForceNullable = true)]
     public string? ManageToken { get; set; }
 }


### PR DESCRIPTION
<details> 
  <summary>Удаление одиночных картинок </summary>
  
Гифка:
![1](https://user-images.githubusercontent.com/116700539/206876043-3d4c00a5-27a8-4118-b2e0-f6a26f320e4f.gif)

Кнопка Delete недоступна для чужих картинок.
</details>

<details> 
  <summary>Добавление одиночных картинок в альбом</summary>
  
Гифка:
![2](https://user-images.githubusercontent.com/116700539/206876124-d26ed625-d63a-4ea1-b049-7674aff86325.gif)

Результат просмотра альбома после операции:
![3](https://user-images.githubusercontent.com/116700539/206876126-9142200a-25a6-422b-9974-c591b28aa94a.PNG)

</details>

<details> 
  <summary>Мультиселект</summary>
  
Гифка:
![4](https://user-images.githubusercontent.com/116700539/206876146-e4738706-011a-4153-8c37-e5366f9a5663.gif)

Кнопка Delete недостпупна, если выбираем чужие картинки
</details>

<details> 
  <summary>Массовое удаление</summary>
  
Гифка:
![5](https://user-images.githubusercontent.com/116700539/206876190-fd407355-4c6e-413c-bb81-53dfa41077b3.gif)


Экран сразу перезагружает список картинок после завершения операции.
</details>


<details> 
  <summary>Массовое добавление картинок в альбом, а, так же, демонстрация залипания панели действий</summary>
  
Гифка:
![6](https://user-images.githubusercontent.com/116700539/206876232-317ac8dd-98e3-4daf-b9e6-ae2486cbb49d.gif)

Результат просмотра альбома после операции:
![7](https://user-images.githubusercontent.com/116700539/206876260-691534df-99b2-4852-90c4-8801323b7a3e.PNG)

</details>

Известные мне косяки:
1. Sticky mode выглядит не очень в режиме прилипания, можешь заценинь на последней гифке
2. Для операций удаления картинок я не нашёл batch-endpoint'а, поэтому я их удаляю по одной в цикле. Не особо критично, но так, может захочешь добаить ендпионт под это дело
3. Кнопка меню для картинок (сверху справа) выглядит не очень для картинок landscape ориентации
4. Не происходит обновление своих альбомов при их изменении - они хранятся в новом сервисе и надо будет добавить обработку, чтобы пинался refreshAlbums при любых модификациях, затрагивающих собственные альбомы
5. Совсем небольшой косяк - при массовом удалении картинок с них сначала спадает выделение, и только потом они пропадают из списка. В идеале, выделение не надо снимать.

Могу поправить косяки до мёрджа, если хочешь, просто скинул пока, что сегодня успел сделать. Может ещё что заметишь.